### PR TITLE
Add authenticateWithResponse for custom responses

### DIFF
--- a/Sources/AuthKit/AuthKit.swift
+++ b/Sources/AuthKit/AuthKit.swift
@@ -259,4 +259,13 @@ public class AuthKit {
         try enclave?.setString(refreshToken, forKey: "refresh_token")
     }
 
+    /// Get refresh token
+    public func getRefreshToken() -> String? {
+        guard let token = refreshToken else {
+            try? unauthenticate()
+            return nil
+        }
+        return token
+    }
+
 }

--- a/Sources/AuthKit/AuthKit.swift
+++ b/Sources/AuthKit/AuthKit.swift
@@ -253,4 +253,10 @@ public class AuthKit {
         NotificationCenter.default.post(name: .authenticated, object: nil)
     }
     
+    /// Manually sets refresh token
+    /// - Parameter refreshToken:
+    public func setRefreshToken(to refreshToken: String) throws {
+        try enclave?.setString(refreshToken, forKey: "refresh_token")
+    }
+
 }

--- a/Sources/AuthKit/Responses/CustomAuthResponse.swift
+++ b/Sources/AuthKit/Responses/CustomAuthResponse.swift
@@ -1,0 +1,8 @@
+//
+//  CustomAuthResponse.swift
+//
+//
+//  Created by Steve Smith on 10/01/2024.
+//
+
+public protocol CustomAuthResponse: Decodable {}


### PR DESCRIPTION
Added a new method to allow someone to pass in a custom response, for example:

```
struct AuthenticationResponse: Decodable {
    let accessToken: String

    enum CodingKeys: String, CodingKey {
        case accessToken = "access_token"
    }
}
```

this is implemented through:

`authKit.authenticateWithResponse(path: path, email: email, password: password, responseType: AuthenticationResponse.self) `

User can then define attributes they want to collect from the response and also set the token from the response:

`Configuration.auth.setBearerToken(to: response.accessToken)`

Added it as two methods as potentially might want to support multiple methods with responses (oAuth & basic) and not just featherweight in the future.